### PR TITLE
Allow redirects from within the same tab to go back in history

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "YouTube Shorts to Video Player",
+  "name": "YouTube Shorts to Video Player Dev",
   "description": "This extension helps you in watching YouTube Shorts by adding features like rewinding, speed controls, skipping, etc.",
   "version": "1.0.0",
   "manifest_version": 3,
@@ -20,5 +20,6 @@
     "128": "images/icon-128.png"
   },
   "background": { "service_worker": "service-worker.js" },
-  "permissions": ["webNavigation", "tabs"]
+  "permissions": ["webNavigation", "tabs", "scripting"],
+  "host_permissions": ["https://www.youtube.com/*"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "YouTube Shorts to Video Player Dev",
+  "name": "YouTube Shorts to Video Player",
   "description": "This extension helps you in watching YouTube Shorts by adding features like rewinding, speed controls, skipping, etc.",
   "version": "1.0.0",
   "manifest_version": 3,

--- a/service-worker.js
+++ b/service-worker.js
@@ -22,7 +22,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     ) {
       console.log("Tab updated - Opened a YouTube Short");
       const shortId = getShortId(changeInfo.url);
-      redirectToVideoPlayer(tabId, shortId);
+      historyAwareRedirectToVideoPlayer(tabId, shortId);
     }
   } else {
     console.log("No redirection since extension is disabled");
@@ -48,5 +48,16 @@ function redirectToVideoPlayer(tabId, shortId) {
   console.log("Redirecting to Video Player");
   chrome.tabs.update(tabId, {
     url: "https://www.youtube.com/watch?v=" + shortId,
+  });
+}
+
+function historyAwareRedirectToVideoPlayer(tabId, shortId) {
+  console.log("Redirecting to Video Player with history awareness");
+  chrome.scripting.executeScript({
+    target: { tabId },
+    args: [shortId],
+    func: (shortIdArg) => {
+      window.location.replace(`https://www.youtube.com/watch?v=${shortIdArg}`);
+    },
   });
 }


### PR DESCRIPTION
## Why?
Fixes #1 

## How?
- Using `chrome.scripting` api, the service worker will inject a browser-side function to replace the url. This enables it to safely go back without it being hijacked.  

## Testing
I did some manually testing it works as expected. 
- Clicking on a short from current tab, goes to the video version of the short, and backing out goes back to the previous URL. 
- Opening a short to a new tab uses the older function. When you back out, it closes the tab. As expected.

 I can write some tests, but you don't really have a testing infra in place.